### PR TITLE
Do not restrict to specific Guzzle HTTP version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
     "minimum-stability": "dev",
     "require": {
         "php": ">=7.2.5",
-        "guzzlehttp/guzzle": "7.4.5"
+        "guzzlehttp/guzzle": "^7.4.5"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
I guess this was restricted to this only version by mistake in 1288ee870717bd52de60558ffe5aea7ad4556fcb